### PR TITLE
add creation years to documents

### DIFF
--- a/html/js/documents.js
+++ b/html/js/documents.js
@@ -120,6 +120,16 @@ d3.json(dataUrl, function (data) {
           idField: 'id',
           nameField: 'value'
         }
+      },
+      {
+        title: 'Year <i>Hicri</i>',
+        field: 'year_of_creation_hicri',
+        headerFilter: 'input'
+      },
+      {
+        title: 'Year <i>Miladi</i>',
+        field: 'year_of_creation_miladi',
+        headerFilter: 'input'
       }
     ],
     footerElement:

--- a/make_chartsjson.py
+++ b/make_chartsjson.py
@@ -88,9 +88,9 @@ docs_data = read_json_file("documents.json")
 
 # Extract years of creation from documents, excluding None values
 years_of_creation = [
-    int(doc["year_of_creation__hicri"])
+    int(doc["year_of_creation_hicri"])
     for doc in docs_data.values()
-    if doc.get("year_of_creation__hicri")
+    if doc.get("year_of_creation_hicri")
 ]
 
 # Create a sorted list of all the decades
@@ -106,7 +106,7 @@ for category in categories_data:
     category_name = category["name"]
     doc_list = [document["id"] for document in category["documents"]]
     for doc in doc_list:
-        year_of_creation = docs_data[doc].get("year_of_creation__hicri")
+        year_of_creation = docs_data[doc].get("year_of_creation_hicri")
         if year_of_creation is not None:
             decade = round_down_to_ten(int(year_of_creation))
             decade_dict[category_name][decade] += 1

--- a/templates/document.j2
+++ b/templates/document.j2
@@ -54,6 +54,18 @@
                 {% endif %}
             </dl>
 
+            <h2><i class="bi bi-calendar4"></i> Year of creation</h2>
+            <dl>
+                {% if object.year_of_creation_hicri %}
+                <dt><i>Hicri</i></dt>
+                <dd class="ms-5">{{ object.year_of_creation_hicri }}</dd>
+                {% endif %}
+                {% if object.year_of_creation_miladi %}
+                <dt><i>Miladi</i></dt>
+                <dd class="ms-5">{{ object.year_of_creation_miladi }}</dd>
+                {% endif %}
+            </dl>
+
             <h2><i class="bi bi-person"></i> <i>Bakkal</i>/Grocer</h2>
             {% for x in object.main_person %}
             <dl>


### PR DESCRIPTION
I also changed the "year_of_creation__hicri" column to "year_of_creation_hicri" (with only one underscore before hicri) in baserow, and some code lines that are using this column accordingly. Everything should work after the next data dump from baserow. 