### PR TITLE
set crop and overflow to none/false for category chart

### DIFF
--- a/html/js/dashboard.js
+++ b/html/js/dashboard.js
@@ -76,7 +76,9 @@ function createColumnChart (containerId, title, data, drilldownData) {
         allowPointSelect: true,
         cursor: 'pointer',
         dataLabels: {
-          enabled: true
+          enabled: true,
+          overflow: 'none',
+          crop: false,
         }
       }
     },


### PR DESCRIPTION
Made sure that the data labels stay on top of the bar. Closes #131 