### PR TITLE
include meta information on good detail page

### DIFF
--- a/templates/good.j2
+++ b/templates/good.j2
@@ -9,6 +9,22 @@
     </h1>
     <div class="row">
         <div class="col">
+            {% if object.turkish_names %}
+            <h2><i class="bi bi-card-text"></i> Translation</h2>
+            <dl>
+                <dd class="ms-5"><b>{{ object.turkish_names }}</b>
+                {% if object.spelling_variations_and_synonyms %}
+                |
+                {{ object.spelling_variations_and_synonyms }}</dd>
+                {% endif %}
+            </dl>
+            {% endif %}
+            {% if object.notes %}
+            <h2><i class="bi bi-info-circle"></i> Description</h2>
+            <dl>
+                <dd class="ms-5">{{ object.notes }}</dd>
+            </dl>
+            {% endif %}
             <h2><i class="bi bi-geo-alt"></i> Categories</h2>
             <dl>
                 {% for x in object.has_category %}
@@ -48,7 +64,7 @@
 
     for (let i = 0; i < doc_list.length; i++) {
         if (doc_list[i].year_of_creation_miladi) {
-            let year = /\d{4}/.exec(doc_list[i].year_of_creation_miladi)[0]; //remove regex espression after simple year values are inserted in baserow
+            let year = /\d{4}/.exec(doc_list[i].year_of_creation_miladi)[0]; //remove regex expression after simple year values are inserted in baserow
             if (doc_list[i].lat && doc_list[i].long) {
                 if (year < 1801) {
                     var eighteenth_marker = L.circleMarker([doc_list[i].lat, doc_list[i].long], {color: color18})


### PR DESCRIPTION
Translations, synonyms, descriptions are included in the good detail page instead of creating an individual glossary page